### PR TITLE
Added an option to receive SSE comments as message events

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -36,14 +36,14 @@ export function createEventSource(
     typeof optionsOrUrl === 'string' || optionsOrUrl instanceof URL
       ? {url: optionsOrUrl}
       : optionsOrUrl
-  const {onMessage, onConnect = noop, onDisconnect = noop, onScheduleReconnect = noop} = options
+  const {onMessage, onConnect = noop, onDisconnect = noop, onScheduleReconnect = noop, withComments = false} = options
   const {fetch, url, initialLastEventId} = validate(options)
   const requestHeaders = {...options.headers} // Prevent post-creation mutations to headers
 
   const onCloseSubscribers: (() => void)[] = []
   const subscribers: ((event: EventSourceMessage) => void)[] = onMessage ? [onMessage] : []
   const emit = (event: EventSourceMessage) => subscribers.forEach((fn) => fn(event))
-  const parser = createParser({onEvent, onRetry})
+  const parser = createParser({onEvent, onComment: withComments ? onComment : noop, onRetry})
 
   // Client state
   let request: Promise<unknown> | null
@@ -236,6 +236,12 @@ export function createEventSource(
     }
 
     emit(msg)
+  }
+
+  function onComment(comment: string) {
+    if (withComments) {
+      emit({event: 'comment', data: comment, id: undefined})
+    }
   }
 
   function onRetry(ms: number) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,9 @@ export interface EventSourceOptions {
   /** Callback that fires each time a new event is received. */
   onMessage?: (event: EventSourceMessage) => void
 
+  /** A boolean for whether comments should also fire as messages (default is to ignore) */
+  withComments?: boolean
+
   /** Callback that fires each time the connection is established (multiple times in the case of reconnects). */
   onConnect?: () => void
 

--- a/test/server.ts
+++ b/test/server.ts
@@ -299,7 +299,7 @@ async function writeTricklingConnection(_req: IncomingMessage, res: ServerRespon
 
   for (let i = 0; i < 60; i++) {
     await delay(500)
-    tryWrite(res, ':\n')
+    tryWrite(res, formatComment(`This is comment #${i + 1}`))
   }
 
   tryWrite(res, formatEvent({event: 'disconnect', data: 'Thanks for listening'}))

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -42,6 +42,29 @@ export function registerTests(options: {
     await deferClose(es)
   })
 
+  test('can receive comments', async () => {
+    const onMessage = getCallCounter()
+    const onDisconnect = getCallCounter()
+    const es = createEventSource({
+      url: new URL(`${baseUrl}:${port}/trickle`),
+      fetch,
+      onMessage,
+      onDisconnect,
+      withComments: true,
+    })
+
+    await onMessage.waitForCallCount(2)
+
+    expect(onMessage.callCount).toBe(2)
+    expect(onMessage.lastCall.lastArg).toMatchObject({
+      data: 'This is comment #1',
+      event: 'comment',
+      id: undefined,
+    })
+
+    await deferClose(es)
+  })
+
   test('can connect using URL only', async () => {
     const es = createEventSource(new URL(`${baseUrl}:${port}/`))
     for await (const event of es) {


### PR DESCRIPTION
For a high-reliability system, in order to be able to more quickly determine when server-client connection is down, we needed to see the keep-alive comments the server is sending over. I took the path of least resistance to expose them through the existing api, using the onMessage event and a boolean switch for whether to include comments or not.

Happy to contribute a different approach if desired.

Pull request includes a test.